### PR TITLE
README: Fix link to snake notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Now that you have learnt the basics of Python, there are quite a lot you can do 
 
 [guessnotes]: https://github.com/oxcompsoc/learntocode/tree/master/guessthenumber
 
-2. [Here][guessnotes] is a tutorial for building a snake game in Python using PyGame. (Difficulty: 4/5)
+2. [Here][snakenotes] is a tutorial for building a snake game in Python using PyGame. (Difficulty: 4/5)
 
 [snakenotes]: https://github.com/oxcompsoc/learntocode/tree/master/snake_game
 


### PR DESCRIPTION
The link in README.md under "Next steps" to the snake game tutorial is currently wrong. This commit corrects it.

By the way, I think the README would be more future-proof and friendly to cloned versions if the links to files inside the repo were relative paths rather than paths to `https://github.com/`.... It should work in the GitHub UI too. What do you think?